### PR TITLE
Disable argument printing on check_keystone

### DIFF
--- a/plugins/check_keystone
+++ b/plugins/check_keystone
@@ -54,7 +54,7 @@ parser.add_argument('--insecure', action='store_true', default=False,
 parser.add_argument('services', metavar='SERVICE', type=str, nargs='*',
                     help='services to check for')
 args = parser.parse_args()
-print args
+#print args
 
 
 try:


### PR DESCRIPTION
By default, check_keystone prints (leaks!) credentials of the account
used for monitoring.  This must be disabled.