### PR TITLE
Reduce verbosity of check_graphite when returned values are null

### DIFF
--- a/plugins/check_graphite.py
+++ b/plugins/check_graphite.py
@@ -82,7 +82,10 @@ def check_graphite(args):
     if len(dps) > 0 and not all_null:
       print "OK: query %s retrieved %d elements" % (query, len(jsonres[0]['datapoints']))
       return STATE_OK
-
+    if all_null:
+      print "Failed: query %s returned all null values" % (query)
+      return STATE_CRITICAL
+    
   print "Failed: query %s returned %s" % (query, result)
 
   if args.failiswarn:

--- a/plugins/check_graphite.py
+++ b/plugins/check_graphite.py
@@ -85,7 +85,7 @@ def check_graphite(args):
     if all_null:
       print "Failed: query %s returned all null values" % (query)
       return STATE_CRITICAL
-    
+
   print "Failed: query %s returned %s" % (query, result)
 
   if args.failiswarn:


### PR DESCRIPTION
When a check returns all nulls, the output can be significant and makes navigating icinga alerts tiresome. This change ensures that if the returned JSON is all null, then the returned value is a short string stating the returned JSON is all nulls.